### PR TITLE
Changed the way that the memory for the activations is calculated

### DIFF
--- a/llm_tools/pages/1_Memory.py
+++ b/llm_tools/pages/1_Memory.py
@@ -95,6 +95,14 @@ num_attention_heads = st.sidebar.number_input(
     key="num_attention_heads",
     help="Number of attention heads in the model (given by the model card).",
 )
+mlp_layer_size = st.sidebar.number_input(
+    "MLP Layer Size",
+    min_value=0,
+    step=1,
+    value=None,
+    key="mlp_layer_size",
+    help="Size of the MLP layer (usually 4x the hidden size).",
+)
 
 
 # ----------------- Main Screen UI ----------------- #
@@ -117,6 +125,7 @@ inference_memory = calculate_inference_memory(
     hidden_size,
     num_hidden_layers,
     num_attention_heads,
+    mlp_layer_size,
 )
 
 inference.write(f"**Total Inference Memory**: {inference_memory['inference_memory']}")
@@ -136,6 +145,7 @@ training_memory = calculate_training_memory(
     num_attention_heads,
     optimizer,
     trainable_parameters,
+    mlp_layer_size,
 )
 
 training1.write(f"**Total Training Memory**: {training_memory['training_memory']}")


### PR DESCRIPTION
Hi,

I noticed that you had pulled a formula for calculating the amount of memory required from [this](https://proceedings.mlsys.org/paper_files/paper/2023/file/80083951326cf5b35e5100260d64ed81-Paper-mlsys2023.pdf) paper. However, the paper makes certain assumptions about what precision floats we are using for the model, and on that basis it comes up with the formula. The code here is made to work with any kind of precision, so I made some edits that make the same formula from the paper more generalised. Hope this helps!

I also realised that KV cache memory is being calculated for training. However, KV caching is only done during inference, so I have removed that from the memory calculation.